### PR TITLE
Fix pagination input bug on IE

### DIFF
--- a/js/pagination-view-model.js
+++ b/js/pagination-view-model.js
@@ -58,6 +58,17 @@ export default class {
     });
     this.pageNumberSize = ko.computed(() => Math.floor(this.pageCount().toString().length));
 
+    this.onKeyPress = (data, event) => {
+      const keyCode = event.which || event.keyCode;
+
+      if (keyCode === 13) {
+        event.target.blur();
+        return false;
+      }
+
+      return true;
+    };
+
     this.skip = ko.computed(() => this.pageNumber() * this.pageSize());
     this.take = ko.computed(() => this.pageSize());
     // initialize the

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     }
   },
   "main": "dist/pagination-control.js",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "files": [
     "dist"
   ],

--- a/template/layout/default.jade
+++ b/template/layout/default.jade
@@ -5,7 +5,7 @@ form.form-inline
     span.input-group-btn
       button.btn.btn-default(data-bind='click: decPageNumber', type='button', aria-label=previousPageText)
         .glyphicon.glyphicon-triangle-left
-    input.form-control(data-bind='value: pageNumberText, attr: { size: pageNumberSize, maxlength: pageNumberSize, disabled: !enableRandomPage()}', type='text')
+    input.form-control(data-bind='value: pageNumberText, attr: { size: pageNumberSize, maxlength: pageNumberSize, disabled: !enableRandomPage() }, event: { keypress: onKeyPress }', type='text')
     span.input-group-addon
       span=totalPageCountText
       span(data-bind='text: pageCount')


### PR DESCRIPTION
**Bug description:** IE don't trigger `change` event when press `Enter` key until the input lose focus.
**Fix:** add event binding to the page number input, listen for `Enter` key press event, and blur the input. 